### PR TITLE
単一音声ファイルの文字起こし機能を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,14 +46,32 @@ python record_audio.py
 
 ### 2. 文字起こし
 
+以下のいずれかの方法で文字起こしを実行できます：
+
+1. 単一の音声ファイルを文字起こし
+```bash
+python transcribe.py -f path/to/audio.wav
+```
+
+2. ディレクトリ内のすべての音声ファイルを文字起こし
+```bash
+python transcribe.py -d path/to/directory
+```
+
+3. デフォルトの`recordings`ディレクトリ内のファイルを文字起こし
 ```bash
 python transcribe.py
 ```
 
-- `recordings`ディレクトリ内の音声ファイルを自動で検出
+オプション:
+- `-f, --file`: 文字起こしする音声ファイルのパス
+- `-d, --directory`: 文字起こしする音声ファイルのディレクトリ
+- `-o, --output`: 出力先ディレクトリ（デフォルト: transcripts）
+
+仕様:
 - 対応フォーマット: .wav, .mp3, .m4a
 - OpenAI Whisper APIを使用して高精度な文字起こし
-- 書き起こされたテキストは`transcripts`ディレクトリに保存
+- 書き起こされたテキストは指定された出力ディレクトリに保存
 - フォーマット: `[HH:MM:SS] 発言内容`
 
 ## 開発

--- a/test_transcribe.py
+++ b/test_transcribe.py
@@ -1,7 +1,7 @@
 import pytest
 from pathlib import Path
 import os
-from transcribe import format_timestamp, transcribe_audio, process_directory
+from transcribe import format_timestamp, transcribe_audio, process_directory, process_single_file
 from unittest.mock import patch, MagicMock
 
 def test_format_timestamp():
@@ -69,3 +69,49 @@ def test_process_directory(mock_openai, tmp_path):
         # 出力を確認
         assert output_dir.exists()
         assert len(list(output_dir.glob("*.txt"))) > 0
+
+@patch('openai.OpenAI')
+def test_process_single_file(mock_openai, tmp_path):
+    """単一ファイル処理機能をテストする"""
+    # モックの設定
+    mock_client = MagicMock()
+    mock_openai.return_value = mock_client
+    
+    mock_response = MagicMock()
+    mock_segment = MagicMock()
+    mock_segment.start = 0
+    mock_segment.text = "テストテキスト"
+    mock_response.segments = [mock_segment]
+    
+    mock_client.audio.transcriptions.create.return_value = mock_response
+    
+    # テスト用のディレクトリ構造を作成
+    output_dir = tmp_path / "transcripts"
+    
+    # テスト用の音声ファイル
+    test_audio = "test_audio.wav"
+    
+    if os.path.exists(test_audio):
+        # 処理を実行
+        output_file = process_single_file(test_audio, str(output_dir))
+        
+        # 出力を確認
+        assert output_dir.exists()
+        assert output_file.exists()
+        assert output_file.suffix == ".txt"
+        
+        # ファイル内容の確認
+        with open(output_file, "r", encoding="utf-8") as f:
+            content = f.read()
+            assert content.startswith("[")
+            assert "テストテキスト" in content
+
+def test_process_single_file_invalid_file():
+    """存在しないファイルを指定した場合のエラーテスト"""
+    with pytest.raises(FileNotFoundError):
+        process_single_file("non_existent_file.wav")
+
+def test_process_single_file_invalid_format():
+    """サポートされていない形式のファイルを指定した場合のエラーテスト"""
+    with pytest.raises(ValueError):
+        process_single_file("test.txt")

--- a/transcribe.py
+++ b/transcribe.py
@@ -1,4 +1,5 @@
 import os
+import argparse
 from pathlib import Path
 from openai import OpenAI
 from datetime import timedelta
@@ -46,6 +47,50 @@ def transcribe_audio(audio_path):
     
     return "\n".join(transcription)
 
+def process_single_file(input_file, output_dir="transcripts"):
+    """
+    単一の音声ファイルを文字起こしする
+    
+    Args:
+        input_file (str): 入力音声ファイルのパス
+        output_dir (str): 出力ディレクトリのパス
+    
+    Returns:
+        Path: 出力ファイルのパス
+    """
+    input_path = Path(input_file)
+    output_path = Path(output_dir)
+    output_path.mkdir(exist_ok=True)
+    
+    # サポートする音声フォーマット
+    audio_extensions = {".mp3", ".wav", ".m4a"}
+    
+    # まず拡張子のチェック
+    if input_path.suffix.lower() not in audio_extensions:
+        raise ValueError(f"サポートされていない音声フォーマットです: {input_path.suffix}")
+    
+    # 次にファイルの存在チェック
+    if not input_path.exists():
+        raise FileNotFoundError(f"ファイルが見つかりません: {input_file}")
+    
+    try:
+        # 文字起こしの実行
+        transcription = transcribe_audio(str(input_path))
+        
+        # 出力ファイル名の設定
+        output_file = output_path / f"{input_path.stem}.txt"
+        
+        # 結果の保存
+        with open(output_file, "w", encoding="utf-8") as f:
+            f.write(transcription)
+        
+        print(f"文字起こし完了: {input_path.name} -> {output_file.name}")
+        return output_file
+    
+    except Exception as e:
+        print(f"エラー発生 ({input_path.name}): {str(e)}")
+        raise
+
 def process_directory(input_dir="recordings", output_dir="transcripts"):
     """
     指定されたディレクトリ内の音声ファイルを全て文字起こしする
@@ -62,20 +107,21 @@ def process_directory(input_dir="recordings", output_dir="transcripts"):
     
     for audio_file in audio_files:
         try:
-            # 文字起こしの実行
-            transcription = transcribe_audio(str(audio_file))
-            
-            # 出力ファイル名の設定
-            output_file = output_path / f"{audio_file.stem}.txt"
-            
-            # 結果の保存
-            with open(output_file, "w", encoding="utf-8") as f:
-                f.write(transcription)
-            
-            print(f"文字起こし完了: {audio_file.name} -> {output_file.name}")
-        
+            process_single_file(audio_file, output_dir)
         except Exception as e:
             print(f"エラー発生 ({audio_file.name}): {str(e)}")
 
 if __name__ == "__main__":
-    process_directory()
+    parser = argparse.ArgumentParser(description="音声ファイルの文字起こしを行います")
+    parser.add_argument("-f", "--file", help="文字起こしする音声ファイルのパス")
+    parser.add_argument("-d", "--directory", help="文字起こしする音声ファイルのディレクトリ")
+    parser.add_argument("-o", "--output", default="transcripts", help="出力先ディレクトリ（デフォルト: transcripts）")
+    
+    args = parser.parse_args()
+    
+    if args.file:
+        process_single_file(args.file, args.output)
+    elif args.directory:
+        process_directory(args.directory, args.output)
+    else:
+        process_directory(output_dir=args.output)


### PR DESCRIPTION
## 概要
音声ファイルを1つずつ指定して文字起こしできる機能を追加しました。
これにより、ディレクトリ内の全ファイルを処理する代わりに、特定のファイルのみを処理することが可能になります。

## 変更内容
- 単一ファイル処理用の`process_single_file()`関数を追加
- コマンドライン引数のサポート追加
  - `-f/--file`: 単一ファイルの指定
  - `-d/--directory`: ディレクトリの指定（既存機能）
  - `-o/--output`: 出力先ディレクトリの指定
- 音声ファイルのバリデーション機能を強化
- READMEに新機能の使用方法を追加

## テスト
- 単一ファイル処理のテストケースを追加
- エラーケース（無効なファイル形式、存在しないファイル）のテストを追加
- 既存のテストも全て成功することを確認済み

## 動作確認方法
```bash
# 単一ファイルの文字起こし
python transcribe.py -f path/to/audio.wav

# 出力先を指定して文字起こし
python transcribe.py -f path/to/audio.wav -o path/to/output