### PR TITLE
書き起こし完了時にOpenAI APIの使用情報（コストとプロンプト）を出力する機能を追加

### DIFF
--- a/test_transcribe.py
+++ b/test_transcribe.py
@@ -1,13 +1,30 @@
 import pytest
 import os
-from transcribe import format_timestamp, transcribe_audio, process_directory, process_single_file
+import json
+from transcribe import (
+    format_timestamp,
+    transcribe_audio,
+    process_directory,
+    process_single_file,
+    calculate_audio_cost
+)
 from unittest.mock import patch, MagicMock
+from pathlib import Path
 
 def test_format_timestamp():
     """タイムスタンプのフォーマット機能をテストする"""
     assert format_timestamp(0) == "[00:00:00]"
     assert format_timestamp(61) == "[00:01:01]"
     assert format_timestamp(3661) == "[01:01:01]"
+
+def test_calculate_audio_cost():
+    """音声コスト計算機能をテストする"""
+    # 1分の音声（$0.006）
+    assert calculate_audio_cost(60) == 0.006
+    # 30秒の音声（$0.003）
+    assert calculate_audio_cost(30) == 0.003
+    # 2分の音声（$0.012）
+    assert calculate_audio_cost(120) == 0.012
 
 @patch('openai.OpenAI')
 def test_transcribe_audio(mock_openai):
@@ -21,6 +38,7 @@ def test_transcribe_audio(mock_openai):
     mock_segment.start = 0
     mock_segment.text = "テストテキスト"
     mock_response.segments = [mock_segment]
+    mock_response.duration = 60  # 1分の音声を想定
     
     mock_client.audio.transcriptions.create.return_value = mock_response
     
@@ -28,11 +46,20 @@ def test_transcribe_audio(mock_openai):
     test_audio = "test_audio.wav"
     
     if os.path.exists(test_audio):
-        result = transcribe_audio(test_audio)
-        assert isinstance(result, str)
-        assert len(result) > 0
-        assert result.startswith("[")
-        assert "]" in result
+        transcription, prompt_info = transcribe_audio(test_audio)
+        # 文字起こしテキストの確認
+        assert isinstance(transcription, str)
+        assert len(transcription) > 0
+        assert transcription.startswith("[")
+        assert "]" in transcription
+        
+        # プロンプト情報の確認
+        assert isinstance(prompt_info, dict)
+        assert prompt_info["model"] == "whisper-1"
+        assert prompt_info["language"] == "ja"
+        assert prompt_info["duration_seconds"] == 60
+        assert prompt_info["cost_usd"] == 0.006
+        assert "timestamp" in prompt_info
 
 @patch('openai.OpenAI')
 def test_process_directory(mock_openai, tmp_path):
@@ -46,6 +73,7 @@ def test_process_directory(mock_openai, tmp_path):
     mock_segment.start = 0
     mock_segment.text = "テストテキスト"
     mock_response.segments = [mock_segment]
+    mock_response.duration = 60
     
     mock_client.audio.transcriptions.create.return_value = mock_response
     
@@ -67,7 +95,15 @@ def test_process_directory(mock_openai, tmp_path):
         
         # 出力を確認
         assert output_dir.exists()
-        assert len(list(output_dir.glob("*.txt"))) > 0
+        output_files = list(output_dir.glob("*.txt"))
+        assert len(output_files) > 0
+        
+        # 出力ファイルの内容を確認
+        with open(output_files[0], "r", encoding="utf-8") as f:
+            content = f.read()
+            assert "[OpenAI API 使用情報]" in content
+            assert "モデル: whisper-1" in content
+            assert "推定コスト: $" in content
 
 @patch('openai.OpenAI')
 def test_process_single_file(mock_openai, tmp_path):
@@ -81,6 +117,7 @@ def test_process_single_file(mock_openai, tmp_path):
     mock_segment.start = 0
     mock_segment.text = "テストテキスト"
     mock_response.segments = [mock_segment]
+    mock_response.duration = 60
     
     mock_client.audio.transcriptions.create.return_value = mock_response
     
@@ -104,6 +141,12 @@ def test_process_single_file(mock_openai, tmp_path):
             content = f.read()
             assert content.startswith("[")
             assert "テストテキスト" in content
+            assert "[OpenAI API 使用情報]" in content
+            assert "モデル: whisper-1" in content
+            assert "言語設定: ja" in content
+            assert "音声の長さ:" in content
+            assert "推定コスト: $" in content
+            assert "処理日時:" in content
 
 def test_process_single_file_invalid_file():
     """存在しないファイルを指定した場合のエラーテスト"""


### PR DESCRIPTION
## 概要
書き起こし完了時にOpenAI APIの使用情報（プロンプトとコスト）を出力する機能を追加しました。
これにより、APIの使用状況とコストの把握が容易になります。

## 変更内容

### 機能追加
- 音声の長さに基づくコスト計算機能の追加
- OpenAI APIの使用情報（モデル、言語設定、コスト等）の記録
- 文字起こしファイルへの使用情報の追記
- 標準出力への使用情報の表示

### 実装詳細
- `calculate_audio_cost`関数の追加：音声の長さからコストを計算
- `transcribe_audio`関数の拡張：プロンプト情報を返すように修正
- 出力ファイルフォーマットの更新：APIの使用情報セクションを追加

### テスト
- コスト計算機能のユニットテスト追加
- プロンプト情報出力のテスト追加
- 既存のテストケースの更新
- すべてのテストが正常に通過することを確認

## 動作確認
実際の音声ファイル（28.11秒）で動作確認を実施：
```
文字起こし完了: recording_20250127_215234.wav -> recording_20250127_215234.txt
音声の長さ: 28.11秒
推定コスト: $0.0028
```

出力ファイルに以下の情報が正しく記録されることを確認：
- 使用モデル（whisper-1）
- 言語設定（ja）
- 音声の長さ
- 推定コスト
- 処理日時
